### PR TITLE
Changes necessary to upgrade to zio 0.6.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ addCommandAlias("check", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck"
 
 val scalazVersion = "7.2.26"
 val testzVersion  = "0.0.5"
-val zioVersion    = "0.5.3"
+val zioVersion    = "0.6.0"
 
 libraryDependencies ++= Seq(
   "org.scalaz" %% "scalaz-core"  % scalazVersion,

--- a/src/test/scala/scalaz/actors/ActorsSuite.scala
+++ b/src/test/scala/scalaz/actors/ActorsSuite.scala
@@ -20,9 +20,9 @@ final class ActorsSuite extends RTS {
         val handler = new Stateful[Int, Nothing, Message] {
           override def receive[A](state: Int, msg: Message[A]): IO[Nothing, (Int, A)] =
             msg match {
-              case Reset    => IO.point((0, ()))
-              case Increase => IO.point((state + 1, ()))
-              case Get      => IO.point((state, state))
+              case Reset    => IO.succeedLazy((0, ()))
+              case Increase => IO.succeedLazy((state + 1, ()))
+              case Get      => IO.succeedLazy((state, state))
             }
         }
 
@@ -47,7 +47,7 @@ final class ActorsSuite extends RTS {
         val handler = new Stateful[Unit, String, Message] {
           override def receive[A](state: Unit, msg: Message[A]): IO[String, (Unit, A)] =
             msg match {
-              case Tick => IO.point(failures.incrementAndGet()) *> IO.fail("failure")
+              case Tick => IO.succeedLazy(failures.incrementAndGet()) *> IO.fail("failure")
             }
         }
 


### PR DESCRIPTION
This resolves #13 

Mainly involved renaming methods in `IO` and `Promise` to the new more consistent naming.

